### PR TITLE
prepare vimeo livestreams via env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ README.md
 EuroPythonBot/config.local.toml
 __pycache__
 .DS_Store
+registered_log.txt
+posted_jobs.txt

--- a/EuroPythonBot/config.toml
+++ b/EuroPythonBot/config.toml
@@ -52,11 +52,11 @@ webhook_id = "ROOM_2578"
 discord_channel_id = "1225453671152877680"
 survey_url = "https://survey.sci-an.com/UZpiArTDj7OzJsAU?s=7"
 
+# livestreams are hidden in env vars. add the livestream links to .secrets
 [programme_notifications.rooms.2578.livestreams]
-# TODO: update URLs
-"2024-04-22" = "https://2024.pycon.de/live"
-"2024-04-23" = "https://2024.pycon.de/live"
-"2024-04-24" = "https://2024.pycon.de/live"
+"2024-04-22" = "LIVESTREAM_URL_KUPPELSAAL_DAY_1"
+"2024-04-23" = "LIVESTREAM_URL_KUPPELSAAL_DAY_2"
+"2024-04-24" = "LIVESTREAM_URL_KUPPELSAAL_DAY_3"
 
 # B09: 2579
 [programme_notifications.rooms.2579]
@@ -65,10 +65,9 @@ discord_channel_id = "1225453705910816868"
 survey_url = "https://survey.sci-an.com/UZpiArTDj7OzJsAU?s=4"
 
 [programme_notifications.rooms.2579.livestreams]
-# TODO: update URLs
-"2024-04-22" = "https://2024.pycon.de/live"
-"2024-04-23" = "https://2024.pycon.de/live"
-"2024-04-24" = "https://2024.pycon.de/live"
+"2024-04-22" = "LIVESTREAM_URL_B09_DAY_1"
+"2024-04-23" = "LIVESTREAM_URL_B09_DAY_2"
+"2024-04-24" = "LIVESTREAM_URL_B09_DAY_3"
 
 # B07-B08: 2580
 [programme_notifications.rooms.2580]
@@ -77,10 +76,9 @@ discord_channel_id = "1225454000800006144"
 survey_url = "https://survey.sci-an.com/UZpiArTDj7OzJsAU?s=5"
 
 [programme_notifications.rooms.2580.livestreams]
-# TODO: update URLs
-"2024-04-22" = "https://2024.pycon.de/live"
-"2024-04-23" = "https://2024.pycon.de/live"
-"2024-04-24" = "https://2024.pycon.de/live"
+"2024-04-22" = "LIVESTREAM_URL_B07_08_DAY_1"
+"2024-04-23" = "LIVESTREAM_URL_B07_08_DAY_2"
+"2024-04-24" = "LIVESTREAM_URL_B07_08_DAY_3"
 
 # B05-B06: 2581
 [programme_notifications.rooms.2581]
@@ -89,10 +87,9 @@ discord_channel_id = "1225454340513464340"
 survey_url = "https://survey.sci-an.com/UZpiArTDj7OzJsAU?s=6"
 
 [programme_notifications.rooms.2581.livestreams]
-# TODO: update URLs
-"2024-04-22" = "https://2024.pycon.de/live"
-"2024-04-23" = "https://2024.pycon.de/live"
-"2024-04-24" = "https://2024.pycon.de/live"
+"2024-04-22" = "LIVESTREAM_URL_B05_06_DAY_1"
+"2024-04-23" = "LIVESTREAM_URL_B05_06_DAY_2"
+"2024-04-24" = "LIVESTREAM_URL_B05_06_DAY_3"
 
 # A1: 2582
 [programme_notifications.rooms.2582]
@@ -101,10 +98,9 @@ discord_channel_id = "1225454099533791303"
 survey_url = "https://survey.sci-an.com/UZpiArTDj7OzJsAU?s=3"
 
 [programme_notifications.rooms.2582.livestreams]
-# TODO: update URLs
-"2024-04-22" = "https://2024.pycon.de/live"
-"2024-04-23" = "https://2024.pycon.de/live"
-"2024-04-24" = "https://2024.pycon.de/live"
+"2024-04-22" = "LIVESTREAM_URL_A1_DAY_1"
+"2024-04-23" = "LIVESTREAM_URL_A1_DAY_2"
+"2024-04-24" = "LIVESTREAM_URL_A1_DAY_3"
 
 # A03-A04: 2583
 [programme_notifications.rooms.2583]
@@ -113,10 +109,9 @@ discord_channel_id = "1225454458935181493"
 survey_url = "https://survey.sci-an.com/UZpiArTDj7OzJsAU?s=1"
 
 [programme_notifications.rooms.2583.livestreams]
-# TODO: update URLs
-"2024-04-22" = "https://2024.pycon.de/live"
-"2024-04-23" = "https://2024.pycon.de/live"
-"2024-04-24" = "https://2024.pycon.de/live"
+"2024-04-22" = "LIVESTREAM_URL_A03_04_DAY_1"
+"2024-04-23" = "LIVESTREAM_URL_A03_04_DAY_2"
+"2024-04-24" = "LIVESTREAM_URL_A03_04_DAY_3"
 
 # A05-A06: 2584
 [programme_notifications.rooms.2584]
@@ -125,7 +120,6 @@ discord_channel_id = "1225453715079827577"
 survey_url = "https://survey.sci-an.com/UZpiArTDj7OzJsAU?s=2"
 
 [programme_notifications.rooms.2584.livestreams]
-# TODO: update URLs
-"2024-04-22" = "https://2024.pycon.de/live"
-"2024-04-23" = "https://2024.pycon.de/live"
-"2024-04-24" = "https://2024.pycon.de/live"
+"2024-04-22" = "LIVESTREAM_URL_A05_06_DAY_1"
+"2024-04-23" = "LIVESTREAM_URL_A05_06_DAY_2"
+"2024-04-24" = "LIVESTREAM_URL_A05_06_DAY_3"

--- a/EuroPythonBot/extensions/programme_notifications/configuration.py
+++ b/EuroPythonBot/extensions/programme_notifications/configuration.py
@@ -31,7 +31,7 @@ class RoomConfiguration:
     discord_channel_id: str = attrs.field(validator=validators.matches_re(r"\d+"))
     webhook_id: str
     survey_url: yarl.URL
-    livestreams: Mapping[str, yarl.URL]
+    livestreams: Mapping[str, str]
 
 
 @attrs.define(frozen=True)

--- a/EuroPythonBot/extensions/programme_notifications/domain/services/session_to_embed.py
+++ b/EuroPythonBot/extensions/programme_notifications/domain/services/session_to_embed.py
@@ -32,7 +32,7 @@ def create_session_embed(
     :return: A Discord embed for this session
     """
     livestream_value = (
-        f"[YouTube]({session.livestream_url})" if session.livestream_url else _FIELD_VALUE_EMTPY
+        f"[Vimeo]({session.livestream_url})" if session.livestream_url else _FIELD_VALUE_EMTPY
     )
     slido_value = f"[Slido]({slido_url})" if slido_url else _FIELD_VALUE_EMTPY
     survey_value = f"[sci-an]({session.survey_url})" if session.survey_url else _FIELD_VALUE_EMTPY

--- a/EuroPythonBot/extensions/programme_notifications/services/session_information.py
+++ b/EuroPythonBot/extensions/programme_notifications/services/session_information.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import attrs
 import yarl
@@ -56,14 +57,16 @@ class SessionInformation:
         return url, experience
 
     def _get_livestream_url(self, session: europython.Session) -> yarl.URL | None:
-        """Get the livestream URL for this session from the config.
+        """Get the livestream env var name for this session from the config and then get the
+        livestream url from the env var.
 
         :param session: The session
         :return: The livestream URL or None
         """
         date = session.slot.start.strftime("%Y-%m-%d")
         try:
-            return self._config.rooms[str(session.slot.room_id)].livestreams[date]
+            env_var_name = self._config.rooms[str(session.slot.room_id)].livestreams[date]
+            return os.getenv(env_var_name)
         except (KeyError, AttributeError):
             return
 

--- a/EuroPythonBot/extensions/programme_notifications/services/session_information.py
+++ b/EuroPythonBot/extensions/programme_notifications/services/session_information.py
@@ -66,7 +66,10 @@ class SessionInformation:
         date = session.slot.start.strftime("%Y-%m-%d")
         try:
             env_var_name = self._config.rooms[str(session.slot.room_id)].livestreams[date]
-            return os.getenv(env_var_name)
+            livestream_url = os.getenv(env_var_name)
+            if livestream_url:
+                return yarl.URL(livestream_url)
+            return None
         except (KeyError, AttributeError):
             return
 

--- a/tests/programme_notifications/domain/test_create_discord_embed_for_session.py
+++ b/tests/programme_notifications/domain/test_create_discord_embed_for_session.py
@@ -68,7 +68,7 @@ def test_create_embed_from_session_information() -> None:
             discord.Field(name="Duration", value="45 minutes", inline=True),
             discord.Field(
                 name="Livestream",
-                value="[YouTube](https://livestreams.com/best-conference-sessions-of-2023)",
+                value="[Vimeo](https://livestreams.com/best-conference-sessions-of-2023)",
                 inline=True,
             ),
             discord.Field(
@@ -472,7 +472,7 @@ def test_duration_is_displayed_correctly(
         ),
         pytest.param(
             yarl.URL("https://some.stream.live/"),
-            "[YouTube](https://some.stream.live/)",
+            "[Vimeo](https://some.stream.live/)",
             id="Livestream URL is available",
         ),
     ],

--- a/tests/programme_notifications/services/test_notifier_schedules_notifications.py
+++ b/tests/programme_notifications/services/test_notifier_schedules_notifications.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import arrow
@@ -93,9 +94,9 @@ async def test_scheduling_notifications_delivers_to_webhooks(
                     "webhook_id": "room_1234",
                     "survey_url": "https://survey.com",
                     "livestreams": {
-                        "2024-04-22": "https://one.livestream.ep",
-                        "2024-04-23": "https://two.livestream.ep",
-                        "2024-04-24": "https://three.livestream.ep",
+                        "2024-04-22": "LIVESTREAM_URL_TEST_DAY_1",
+                        "2024-04-23": "LIVESTREAM_URL_TEST_DAY_2",
+                        "2024-04-24": "LIVESTREAM_URL_TEST_DAY_3",
                     },
                 }
             },
@@ -109,6 +110,11 @@ async def test_scheduling_notifications_delivers_to_webhooks(
             ],
         }
     )
+
+    os.environ["LIVESTREAM_URL_TEST_DAY_1"] = "https://one.livestream.ep"
+    os.environ["LIVESTREAM_URL_TEST_DAY_2"] = "https://two.livestream.ep"
+    os.environ["LIVESTREAM_URL_TEST_DAY_3"] = "https://three.livestream.ep"
+
     # AND a session information service with the session
     session_info = services.SessionInformation(
         session_repository=repositories.SessionRepository(),

--- a/tests/programme_notifications/services/test_notifier_schedules_notifications.py
+++ b/tests/programme_notifications/services/test_notifier_schedules_notifications.py
@@ -154,7 +154,7 @@ async def test_scheduling_notifications_delivers_to_webhooks(
                         discord.Field(name="Duration", value="37 minutes", inline=True),
                         discord.Field(
                             name="Livestream",
-                            value="[YouTube](https://one.livestream.ep)",
+                            value="[Vimeo](https://one.livestream.ep)",
                             inline=True,
                         ),
                         discord.Field(
@@ -199,7 +199,7 @@ async def test_scheduling_notifications_delivers_to_webhooks(
                         discord.Field(name="Duration", value="37 minutes", inline=True),
                         discord.Field(
                             name="Livestream",
-                            value="[YouTube](https://one.livestream.ep)",
+                            value="[Vimeo](https://one.livestream.ep)",
                             inline=True,
                         ),
                         discord.Field(
@@ -244,7 +244,7 @@ async def test_scheduling_notifications_delivers_to_webhooks(
                         discord.Field(name="Duration", value="37 minutes", inline=True),
                         discord.Field(
                             name="Livestream",
-                            value="[YouTube](https://one.livestream.ep)",
+                            value="[Vimeo](https://one.livestream.ep)",
                             inline=True,
                         ),
                         discord.Field(


### PR DESCRIPTION
We have different livestream URLs per room per day.
We get the URLs for the day every evening before (or in the morning).

My idea for the deployment is to store environment variables per room per day instead of having the URLs directly in the config. In doing so, we can read the URLs from the env vars instead of the config. These env vars (and their livestream URLs are stored in the `.secrets` file.
We can add the URLs as soon as we have them to the `.secrets` file on the server (every evening/morning) and restart/redeloy the bot so the new URLs are there.